### PR TITLE
Add documentation for TypeScript definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ const Providers = {
 ```
 
 ## TypeScript
-Developer who are using TypeScript could include type definitions from [fitbit-weather-types](https://github.com/JeremyJeanson/fitbit-weather-types).
+Developer who are using TypeScript could include type definitions from [](https://www.npmjs.com/package/@types/fitbit-weather) or [fitbit-weather-types](https://github.com/JeremyJeanson/fitbit-weather-types).
 
 ```javascript
-npm i fitbit-weather-types
+npm i @types/fitbit-weather
 ```
 
 ## Contribution

--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ const Providers = {
 }
 ```
 
+## TypeScript
+Developer who are using TypeScript could include type definitions from [fitbit-weather-types](https://github.com/JeremyJeanson/fitbit-weather-types).
+
+```javascript
+npm i fitbit-weather-types
+```
+
 ## Contribution
 
 I'm not a javascript expert so every comment/code reactoring/best practice is appreciated. Don't hesitate to make PR and tell me what's wrong.


### PR DESCRIPTION
Hi Grégoire,

I shared type definitions for your module. They are available for here [fitbit-weather-types](https://github.com/JeremyJeanson/fitbit-weather-types).

I had the link to the readme to help TypeScript developers to be more productive when the use your module.